### PR TITLE
Drop Railtie initializer

### DIFF
--- a/lib/active_job/uniqueness/patch.rb
+++ b/lib/active_job/uniqueness/patch.rb
@@ -72,18 +72,8 @@ module ActiveJob
       end
     end
 
-    if defined?(Rails)
-      class Railtie < Rails::Railtie
-        initializer 'active_job_uniqueness.patch_active_job' do
-          ActiveSupport.on_load(:active_job) do
-            ActiveJob::Base.include ActiveJob::Uniqueness::Patch
-          end
-        end
-      end
-    else
-      ActiveSupport.on_load(:active_job) do
-        ActiveJob::Base.include ActiveJob::Uniqueness::Patch
-      end
+    ActiveSupport.on_load(:active_job) do
+      ActiveJob::Base.include ActiveJob::Uniqueness::Patch
     end
   end
 end


### PR DESCRIPTION
The Railtie initializer makes the patch to be applied much later than ActiveJob is loaded.
It could lead to a NoMethodError if something unusual happens during Rails application load (like calling `Rails.application.eager_load!` in an initializer)

```
NoMethodError: undefined method `unique' for MyJob:Class
```

fixes #3