### PR TITLE
Pass hash as keyword arguments to lock_strategy

### DIFF
--- a/lib/active_job/uniqueness/patch.rb
+++ b/lib/active_job/uniqueness/patch.rb
@@ -55,7 +55,7 @@ module ActiveJob
       end
 
       def lock_strategy
-        @lock_strategy ||= lock_strategy_class.new(lock_options.merge(lock_key: lock_key, job: self))
+        @lock_strategy ||= lock_strategy_class.new(**lock_options.merge(lock_key: lock_key, job: self))
       end
 
       # Override in your job class if you want to customize arguments set for a digest.


### PR DESCRIPTION
This causes deprecation warnings as the Strategies::Base class is defined with kwargs and hash is passed