### PR TITLE
Fix deprecation warnings of ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/activejob-uniqueness/compare/v0.1.3...HEAD)
 
+### Fixed
+- [#11](https://github.com/veeqo/activejob-uniqueness/pull/11) Fix deprecation warnings for ruby 2.7 by [@DanAndreasson](https://github.com/DanAndreasson)
+- [#13](https://github.com/veeqo/activejob-uniqueness/pull/13) Fix deprecation warnings for ruby 2.7
+
 ## [0.1.3](https://github.com/veeqo/activejob-uniqueness/compare/v0.1.2...v0.1.3) - 2020-08-17
 
 ### Fixed

--- a/lib/active_job/uniqueness.rb
+++ b/lib/active_job/uniqueness.rb
@@ -40,8 +40,8 @@ module ActiveJob
         @lock_manager ||= ActiveJob::Uniqueness::LockManager.new(config.redlock_servers, config.redlock_options)
       end
 
-      def unlock!(*args)
-        lock_manager.delete_locks(ActiveJob::Uniqueness::LockKey.new(*args).wildcard_key)
+      def unlock!(**args)
+        lock_manager.delete_locks(ActiveJob::Uniqueness::LockKey.new(**args).wildcard_key)
       end
 
       def test_mode!

--- a/spec/support/locks_helpers.rb
+++ b/spec/support/locks_helpers.rb
@@ -3,16 +3,16 @@
 require 'redis'
 
 module LocksHelpers
-  def cleanup_locks(*args)
-    ActiveJob::Uniqueness.unlock!(*args)
+  def cleanup_locks(**args)
+    ActiveJob::Uniqueness.unlock!(**args)
   end
 
-  def locks(*args)
-    Redis.current.keys(ActiveJob::Uniqueness::LockKey.new(*args).wildcard_key)
+  def locks(**args)
+    Redis.current.keys(ActiveJob::Uniqueness::LockKey.new(**args).wildcard_key)
   end
 
-  def locks_expirations(*args)
-    locks(*args).map { |key| Redis.current.ttl(key) }
+  def locks_expirations(**args)
+    locks(**args).map { |key| Redis.current.ttl(key) }
   end
 
   def set_lock(job_class, arguments:)
@@ -33,7 +33,7 @@ RSpec::Matchers.define :lock do |job_class|
     lock_params = { job_class_name: job_class.name }
     lock_params[:arguments] = @lock_arguments if @lock_arguments
 
-    expect { actual.call }.to change { locks(lock_params).count }.by(1)
+    expect { actual.call }.to change { locks(**lock_params).count }.by(1)
   end
 
   chain :by_args do |*lock_arguments|
@@ -52,7 +52,7 @@ RSpec::Matchers.define :unlock do |job_class|
     lock_params = { job_class_name: job_class.name }
     lock_params[:arguments] = @lock_arguments if @lock_arguments
 
-    expect { actual.call }.to change { locks(lock_params).count }.by(-1)
+    expect { actual.call }.to change { locks(**lock_params).count }.by(-1)
   end
 
   chain :by_args do |*lock_arguments|


### PR DESCRIPTION
Ruby 2.7 deprecates automatic conversion from a hash to keyword arguments

Continues trend of https://github.com/veeqo/activejob-uniqueness/pull/7 and https://github.com/veeqo/activejob-uniqueness/pull/11