### PR TITLE
Do not apply Sidekiq patch automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#22](https://github.com/veeqo/activejob-uniqueness/pull/22) Test with ruby 3.0.1
 
 ### Changed
+- [#20](https://github.com/veeqo/activejob-uniqueness/pull/20) **Breaking** Sidekiq patch is not applied automatically anymore
 - [#21](https://github.com/veeqo/activejob-uniqueness/pull/21) Migrate from Travis to Github Actions
 - [#24](https://github.com/veeqo/activejob-uniqueness/pull/24) The default value for `retry_count` of redlock is now 0
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Add the `activejob-uniqueness` gem to your Gemfile.
 gem 'activejob-uniqueness'
 ```
 
+If you want jobs unlocking for Sidekiq Web UI, require the patch explicitly. [**Queues cleanup becomes slower!**](#sidekiq-api-support)
+```ruby
+gem 'activejob-uniqueness', require: 'active_job/uniqueness/sidekiq_patch'
+```
+
 And run `bundle install` command.
 
 ## Configuration
@@ -169,9 +174,14 @@ bundle
 rake
 ```
 
-## Sidekiq adapter support
+## Sidekiq API support
 
-ActiveJob::Uniqueness patches Sidekiq API to unset locks on jobs cleanup. Starting Sidekiq 5.1 job death also triggers locks cleanup.
+ActiveJob::Uniqueness supports Sidekiq API to unset job locks on queues cleanup (e.g. via Sidekiq Web UI). Starting Sidekiq 5.1 job death also triggers locks cleanup.
+Take into account that **[big queues clanup becomes much slower](https://github.com/veeqo/activejob-uniqueness/issues/16)** because each job is being unlocked individually. In order to activate Sidekiq API patch require it explicitly in your Gemfile:
+
+```ruby
+gem 'activejob-uniqueness', require: 'active_job/uniqueness/sidekiq_patch'
+```
 
 ## Contributing
 

--- a/lib/active_job/uniqueness.rb
+++ b/lib/active_job/uniqueness.rb
@@ -8,14 +8,6 @@ require 'active_job/uniqueness/errors'
 require 'active_job/uniqueness/log_subscriber'
 require 'active_job/uniqueness/active_job_patch'
 
-begin
-  require 'sidekiq/api'
-rescue LoadError
-  # ¯\_(ツ)_/¯
-else
-  require 'active_job/uniqueness/sidekiq_patch'
-end
-
 module ActiveJob
   module Uniqueness
     extend ActiveSupport::Autoload

--- a/lib/active_job/uniqueness/sidekiq_patch.rb
+++ b/lib/active_job/uniqueness/sidekiq_patch.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'activejob/uniqueness'
+require 'sidekiq/api'
+
 module ActiveJob
   module Uniqueness
     def self.unlock_sidekiq_job!(job_data)

--- a/spec/active_job/uniqueness/sidekiq_patch_spec.rb
+++ b/spec/active_job/uniqueness/sidekiq_patch_spec.rb
@@ -1,141 +1,140 @@
 # frozen_string_literal: true
 
-if defined?(Sidekiq)
-  describe 'Sidekiq patch', type: :integration do
-    shared_examples_for 'locks release' do
-      class self::SidekiqWorker
-        include Sidekiq::Worker
-      end
+describe 'Sidekiq patch', :sidekiq, type: :integration do
+  shared_examples_for 'locks release' do
+    let(:sidekiq_worker) do
+      stub_const('MySidekiqWorker', Class.new { include Sidekiq::Worker })
+    end
 
-      context 'when queue adapter is Sidekiq', active_job_adapter: :sidekiq do
-        context 'when job class has unique strategy enabled' do
-          class self::Job < ActiveJob::Base
-            unique :until_executed
-          end
+    after { Sidekiq::Queue.all.each(&:clear) }
 
-          it 'releases the lock' do
-            expect { subject }.to change { locks(job_class_name: self.class::Job.name).count }.by(-1)
-          end
+    context 'when queue adapter is Sidekiq', active_job_adapter: :sidekiq do
+      context 'when job class has unique strategy enabled' do
+        let!(:activejob_worker) do
+          stub_const('MyActiveJob', Class.new(ActiveJob::Base) { unique :until_executed })
         end
 
-        context 'when job class has no unique strategy enabled' do
-          class self::Job < ActiveJob::Base
-          end
-
-          include_examples 'no unlock attempts'
+        it 'releases the lock' do
+          expect { subject }.to change { locks(job_class_name: activejob_worker.name).count }.by(-1)
         end
       end
 
-      context 'when queue adapter is not Sidekiq', active_job_adapter: :test do
-        context 'when job class has unique strategy enabled' do
-          class self::Job < ActiveJob::Base
-            unique :until_executed
-          end
-
-          include_examples 'no unlock attempts'
-        end
-      end
-    end
-
-    describe 'scheduled set item delete' do
-      subject { Sidekiq::ScheduledSet.new.each(&:delete) }
-
-      before do
-        Sidekiq::ScheduledSet.new.clear
-        self.class::SidekiqWorker.perform_in(3.minutes, 123)
-        self.class::Job.set(wait: 3.minutes).perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'scheduled set item remove_job' do
-      subject { Sidekiq::ScheduledSet.new.each { |entry| entry.send(:remove_job) { |_| } } }
-
-      before do
-        Sidekiq::ScheduledSet.new.clear
-        self.class::SidekiqWorker.perform_in(3.minutes, 123)
-        self.class::Job.set(wait: 3.minutes).perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'scheduled set clear' do
-      subject { Sidekiq::ScheduledSet.new.clear }
-
-      before do
-        Sidekiq::ScheduledSet.new.clear
-        self.class::SidekiqWorker.perform_in(3.minutes, 123)
-        self.class::Job.set(wait: 3.minutes).perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'job delete' do
-      subject { Sidekiq::Queue.new('default').each(&:delete) }
-
-      before do
-        Sidekiq::Queue.new('default').clear
-        self.class::SidekiqWorker.perform_async(123)
-        self.class::Job.perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'queue clear' do
-      subject { Sidekiq::Queue.new('default').clear }
-
-      before do
-        Sidekiq::Queue.new('default').clear
-        self.class::SidekiqWorker.perform_async(123)
-        self.class::Job.perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'job set clear' do
-      subject { Sidekiq::JobSet.new('schedule').clear }
-
-      before do
-        Sidekiq::JobSet.new('schedule').clear
-        self.class::SidekiqWorker.perform_in(3.minutes, 123)
-        self.class::Job.set(wait: 3.minutes).perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    describe 'job delete' do
-      subject { Sidekiq::Queue.new('default').each(&:delete) }
-
-      before do
-        self.class::SidekiqWorker.perform_async(123)
-        self.class::Job.perform_later(321)
-      end
-
-      include_examples 'locks release'
-    end
-
-    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('5.1')
-      describe 'job death' do
-        subject do
-          Sidekiq::Queue.new('default').each do |job|
-            Sidekiq::DeadSet.new.kill(job.value)
-          end
+      context 'when job class has no unique strategy enabled' do
+        let!(:activejob_worker) do
+          stub_const('MyActiveJob', Class.new(ActiveJob::Base))
         end
 
-        before do
-          Sidekiq::Queue.new('default').clear
-          self.class::SidekiqWorker.perform_async(123)
-          self.class::Job.perform_later(321)
-        end
-
-        include_examples 'locks release'
+        include_examples 'no unlock attempts'
       end
     end
+
+    context 'when queue adapter is not Sidekiq', active_job_adapter: :test do
+      context 'when job class has unique strategy enabled' do
+        let!(:activejob_worker) do
+          stub_const('MyActiveJob', Class.new(ActiveJob::Base) { unique :until_executed })
+        end
+
+        include_examples 'no unlock attempts'
+      end
+    end
+  end
+
+  describe 'scheduled set item delete' do
+    subject { Sidekiq::ScheduledSet.new.each(&:delete) }
+
+    before do
+      Sidekiq::ScheduledSet.new.clear
+      sidekiq_worker.perform_in(3.minutes, 123)
+      activejob_worker.set(wait: 3.minutes).perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'scheduled set item remove_job' do
+    subject { Sidekiq::ScheduledSet.new.each { |entry| entry.send(:remove_job) { |_| } } }
+
+    before do
+      Sidekiq::ScheduledSet.new.clear
+      sidekiq_worker.perform_in(3.minutes, 123)
+      activejob_worker.set(wait: 3.minutes).perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'scheduled set clear' do
+    subject { Sidekiq::ScheduledSet.new.clear }
+
+    before do
+      Sidekiq::ScheduledSet.new.clear
+      sidekiq_worker.perform_in(3.minutes, 123)
+      activejob_worker.set(wait: 3.minutes).perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'job delete' do
+    subject { Sidekiq::Queue.new('default').each(&:delete) }
+
+    before do
+      Sidekiq::Queue.new('default').clear
+      sidekiq_worker.perform_async(123)
+      activejob_worker.perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'queue clear' do
+    subject { Sidekiq::Queue.new('default').clear }
+
+    before do
+      Sidekiq::Queue.new('default').clear
+      sidekiq_worker.perform_async(123)
+      activejob_worker.perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'job set clear' do
+    subject { Sidekiq::JobSet.new('schedule').clear }
+
+    before do
+      Sidekiq::JobSet.new('schedule').clear
+      sidekiq_worker.perform_in(3.minutes, 123)
+      activejob_worker.set(wait: 3.minutes).perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'job delete' do
+    subject { Sidekiq::Queue.new('default').each(&:delete) }
+
+    before do
+      sidekiq_worker.perform_async(123)
+      activejob_worker.perform_later(321)
+    end
+
+    include_examples 'locks release'
+  end
+
+  describe 'job death', sidekiq: :job_death do
+    subject do
+      Sidekiq::Queue.new('default').each do |job|
+        Sidekiq::DeadSet.new.kill(job.value)
+      end
+    end
+
+    before do
+      Sidekiq::Queue.new('default').clear
+      sidekiq_worker.perform_async(123)
+      activejob_worker.perform_later(321)
+    end
+
+    include_examples 'locks release'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'active_job/uniqueness'
 require 'pry-byebug'
+
+begin
+  require 'sidekiq/api'
+rescue LoadError
+  require 'active_job/uniqueness'
+else
+  require 'active_job/uniqueness/sidekiq_patch'
+end
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,12 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  if defined?(Sidekiq)
+    config.filter_run_excluding(sidekiq: :job_death) if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('5.1')
+  else
+    config.filter_run_excluding(:sidekiq)
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
Deleting many items in the queue via Sidekiq Web UI results in timeouts because each job is being unlocked individually.
Since this change Sidekiq API patch should be applied explicitly in Gemfile:

```ruby
gem 'activejob-uniqueness', require: 'active_job/uniqueness/sidekiq_patch'
```

fixes #16