### PR TITLE
Set retry_count of redlock to 0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - [#21](https://github.com/veeqo/activejob-uniqueness/pull/21) Migrate from Travis to Github Actions
+- [#24](https://github.com/veeqo/activejob-uniqueness/pull/24) The default value for `retry_count` of redlock is now 0
 
 ## [0.1.4](https://github.com/veeqo/activejob-uniqueness/compare/v0.1.3...v0.1.4) - 2020-09-22
 

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -15,7 +15,7 @@ module ActiveJob
       config_accessor(:lock_prefix) { 'activejob_uniqueness' }
       config_accessor(:on_conflict) { :raise }
       config_accessor(:redlock_servers) { [ENV.fetch('REDIS_URL', 'redis://localhost:6379')] }
-      config_accessor(:redlock_options) { {} }
+      config_accessor(:redlock_options) { { retry_count: 0 } }
       config_accessor(:lock_strategies) { {} }
 
       config_accessor(:digest_method) do

--- a/lib/generators/active_job/uniqueness/templates/config/initializers/active_job_uniqueness.rb
+++ b/lib/generators/active_job/uniqueness/templates/config/initializers/active_job_uniqueness.rb
@@ -31,7 +31,7 @@ ActiveJob::Uniqueness.configure do |config|
   # Custom options for Redlock.
   # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration
   #
-  # config.redlock_options = {}
+  # config.redlock_options = { retry_count: 0 }
 
   # Custom strategies.
   # config.lock_strategies = { my_strategy: MyStrategy }

--- a/spec/active_job/uniqueness/configure_spec.rb
+++ b/spec/active_job/uniqueness/configure_spec.rb
@@ -15,7 +15,7 @@ describe ActiveJob::Uniqueness, '.configure' do
                         .and not_change { config.on_conflict }.from(:raise)
                         .and not_change { config.digest_method }.from(OpenSSL::Digest::MD5)
                         .and not_change { config.redlock_servers }.from([redis_url])
-                        .and not_change { config.redlock_options }.from({})
+                        .and not_change { config.redlock_options }.from({ retry_count: 0 })
                         .and not_change { config.lock_strategies }.from({})
     end
   end
@@ -30,7 +30,7 @@ describe ActiveJob::Uniqueness, '.configure' do
         c.on_conflict = :log
         c.digest_method = OpenSSL::Digest::SHA1
         c.redlock_servers = [Redis.current]
-        c.redlock_options = { redis_timeout: 0.01, retry_count: 0 }
+        c.redlock_options = { redis_timeout: 0.01, retry_count: 2 }
         c.lock_strategies = { my_strategy: self.class::MyStrategy }
       end
     end
@@ -41,7 +41,7 @@ describe ActiveJob::Uniqueness, '.configure' do
                         .and change { config.on_conflict }.from(:raise).to(:log)
                         .and change { config.digest_method }.from(OpenSSL::Digest::MD5).to(OpenSSL::Digest::SHA1)
                         .and change { config.redlock_servers }.from([redis_url]).to([Redis.current])
-                        .and change { config.redlock_options }.from({}).to({ redis_timeout: 0.01, retry_count: 0 })
+                        .and change { config.redlock_options }.from({ retry_count: 0 }).to({ redis_timeout: 0.01, retry_count: 2 })
                         .and change { config.lock_strategies }.from({}).to({ my_strategy: self.class::MyStrategy })
     end
   end


### PR DESCRIPTION
The default value of retry_count of redlock-rb is 3. This setting stands for a number of attempts to set the lock, not the number of retries on Redis connection error.

It adds extra delay on jobs enqueuing if jobs have uniqueness strategies until_executing, until_executed, until_expired, or until_and_while_executing. While some retries might be helpful for locking on execution, the activejob-uniqueness is more about jobs uniqueness and it should process lock conflicts as fast as possible in order not to slow jobs enqueuing down.

fixes #23