### PR TITLE
Add ability to set a custom runtime lock key for `:until_and_while_executing` strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/activejob-uniqueness/compare/v0.2.1...HEAD)
 
+### Added
+- [#32](https://github.com/veeqo/activejob-uniqueness/pull/32) Add ability to set a custom runtime lock key for `:until_and_while_executing` strategy
+
 ## [0.2.1](https://github.com/veeqo/activejob-uniqueness/compare/v0.2.0...v0.2.1) - 2021-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ class MyJob < ActiveJob::Base
   def lock_key
     'qux' # completely custom lock key
   end
+
+  def runtime_lock_key
+    'quux' # completely custom runtime lock key for :until_and_while_executing
+  end
 end
 ```
 

--- a/lib/active_job/uniqueness/active_job_patch.rb
+++ b/lib/active_job/uniqueness/active_job_patch.rb
@@ -55,7 +55,7 @@ module ActiveJob
       end
 
       def lock_strategy
-        @lock_strategy ||= lock_strategy_class.new(**lock_options.merge(lock_key: lock_key, job: self))
+        @lock_strategy ||= lock_strategy_class.new(job: self)
       end
 
       # Override in your job class if you want to customize arguments set for a digest.
@@ -64,11 +64,11 @@ module ActiveJob
       end
 
       # Override lock_key method in your job class if you want to build completely custom lock key.
-      delegate :lock_key, to: :lock_key_generator
+      delegate :lock_key, :runtime_lock_key, to: :lock_key_generator
 
       def lock_key_generator
-        ActiveJob::Uniqueness::LockKey.new job_class_name: self.class.name,
-                                           arguments: lock_key_arguments
+        @lock_key_generator ||= ActiveJob::Uniqueness::LockKey.new job_class_name: self.class.name,
+                                                                   arguments: lock_key_arguments
       end
     end
 

--- a/lib/active_job/uniqueness/lock_key.rb
+++ b/lib/active_job/uniqueness/lock_key.rb
@@ -28,6 +28,14 @@ module ActiveJob
         ].join(':')
       end
 
+      # used only by :until_and_while_executing strategy
+      def runtime_lock_key
+        [
+          lock_key,
+          'runtime'
+        ].join(':')
+      end
+
       def wildcard_key
         [
           lock_prefix,

--- a/lib/active_job/uniqueness/strategies/base.rb
+++ b/lib/active_job/uniqueness/strategies/base.rb
@@ -13,10 +13,10 @@ module ActiveJob
 
         attr_reader :lock_key, :lock_ttl, :on_conflict, :job
 
-        def initialize(lock_key:, lock_ttl: nil, on_conflict: nil, job: nil)
-          @lock_key = lock_key
-          @lock_ttl = (lock_ttl || config.lock_ttl).to_i * 1000 # ms
-          @on_conflict = on_conflict || config.on_conflict
+        def initialize(job:)
+          @lock_key = job.lock_key
+          @lock_ttl = (job.lock_options[:lock_ttl] || config.lock_ttl).to_i * 1000 # ms
+          @on_conflict = job.lock_options[:on_conflict] || config.on_conflict
           @job = job
         end
 

--- a/spec/active_job/uniqueness/lock_key/runtime_lock_key_spec.rb
+++ b/spec/active_job/uniqueness/lock_key/runtime_lock_key_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe ActiveJob::Uniqueness::LockKey, '#runtime_lock_key' do
+  subject { lock_key.runtime_lock_key }
+
+  let(:lock_key) { described_class.new(job_class_name: job_class_name, arguments: arguments) }
+  let(:job_class_name) { 'FooBarJob' }
+  let(:arguments) { ['baz'] }
+
+  context 'when default configuration is used' do
+    it { is_expected.to eq 'activejob_uniqueness:foo_bar_job:143654a5f0a059a178924baf9b815ea6:runtime' }
+  end
+
+  context 'when job class has namespace' do
+    let(:job_class_name) { 'Foo::BarJob' }
+
+    it { is_expected.to eq 'activejob_uniqueness:foo/bar_job:143654a5f0a059a178924baf9b815ea6:runtime' }
+  end
+
+  context 'when custom lock_prefix is set' do
+    before { allow(ActiveJob::Uniqueness.config).to receive(:lock_prefix).and_return('custom') }
+
+    it { is_expected.to eq 'custom:foo_bar_job:143654a5f0a059a178924baf9b815ea6:runtime' }
+  end
+
+  context 'when custom digest_method is set' do
+    before { allow(ActiveJob::Uniqueness.config).to receive(:digest_method).and_return(OpenSSL::Digest::SHA1) }
+
+    it { is_expected.to eq 'activejob_uniqueness:foo_bar_job:c8246148dacbed08f65913be488195317569f8dd:runtime' }
+  end
+
+  context 'when nil arguments given' do
+    let(:arguments) { nil }
+
+    it { is_expected.to eq 'activejob_uniqueness:foo_bar_job:no_arguments:runtime' }
+  end
+
+  context 'when [] arguments given' do
+    let(:arguments) { [] }
+
+    it { is_expected.to eq 'activejob_uniqueness:foo_bar_job:no_arguments:runtime' }
+  end
+end

--- a/spec/active_job/uniqueness/strategies/until_executed_spec.rb
+++ b/spec/active_job/uniqueness/strategies/until_executed_spec.rb
@@ -44,4 +44,48 @@ describe ':until_executed strategy', type: :integration do
       end
     end
   end
+
+  describe 'lock key' do
+    let(:job) { job_class.new(2, 1) }
+
+    before { job.lock_strategy.before_enqueue }
+
+    context 'when the job has no custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_executed
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+        end
+      end
+
+      it 'locks the job with the default lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to match(/\Aactivejob_uniqueness:my_job:[^:]+\z/)
+      end
+    end
+
+    context 'when the job has a custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_executed
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+
+          def lock_key
+            'activejob_uniqueness:whatever'
+          end
+        end
+      end
+
+      it 'locks the job with the custom lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to eq 'activejob_uniqueness:whatever'
+      end
+    end
+  end
 end

--- a/spec/active_job/uniqueness/strategies/until_executing_spec.rb
+++ b/spec/active_job/uniqueness/strategies/until_executing_spec.rb
@@ -44,4 +44,48 @@ describe ':until_executing strategy', type: :integration do
       end
     end
   end
+
+  describe 'lock key' do
+    let(:job) { job_class.new(2, 1) }
+
+    before { job.lock_strategy.before_enqueue }
+
+    context 'when the job has no custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_executing
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+        end
+      end
+
+      it 'locks the job with the default lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to match(/\Aactivejob_uniqueness:my_job:[^:]+\z/)
+      end
+    end
+
+    context 'when the job has a custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_executing
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+
+          def lock_key
+            'activejob_uniqueness:whatever'
+          end
+        end
+      end
+
+      it 'locks the job with the custom lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to eq 'activejob_uniqueness:whatever'
+      end
+    end
+  end
 end

--- a/spec/active_job/uniqueness/strategies/until_expired_spec.rb
+++ b/spec/active_job/uniqueness/strategies/until_expired_spec.rb
@@ -44,4 +44,48 @@ describe ':until_expired strategy', type: :integration do
       end
     end
   end
+
+  describe 'lock key' do
+    let(:job) { job_class.new(2, 1) }
+
+    before { job.lock_strategy.before_enqueue }
+
+    context 'when the job has no custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_expired
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+        end
+      end
+
+      it 'locks the job with the default lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to match(/\Aactivejob_uniqueness:my_job:[^:]+\z/)
+      end
+    end
+
+    context 'when the job has a custom #lock_key defined' do
+      let(:job_class) do
+        stub_active_job_class do
+          unique :until_expired
+
+          def perform(number1, number2)
+            number1 / number2
+          end
+
+          def lock_key
+            'activejob_uniqueness:whatever'
+          end
+        end
+      end
+
+      it 'locks the job with the custom lock key' do
+        expect(locks.size).to eq 1
+        expect(locks.first).to eq 'activejob_uniqueness:whatever'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds ability to set a custom `runtime_lock_key` for `:until_and_while_executing` strategy

```ruby
class MyJob < ApplicationJob
  unique :until_and_while_executing

  def perform(args)
    # rocket_science(args)
  end

  def runtime_lock_key
    'my_lock_key_for_job_locking_while_it_is_being_performed'
  end
end
```