### PR TITLE
method to reset lock manager to default

### DIFF
--- a/lib/active_job/uniqueness.rb
+++ b/lib/active_job/uniqueness.rb
@@ -38,6 +38,10 @@ module ActiveJob
       def test_mode!
         @lock_manager = ActiveJob::Uniqueness::TestLockManager.new
       end
+
+      def reset_manager!
+        @lock_manager = nil
+      end
     end
   end
 end

--- a/spec/active_job/uniqueness/test_mode_spec.rb
+++ b/spec/active_job/uniqueness/test_mode_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe ActiveJob::Uniqueness, '.test_mode!', type: :integration do
+  let(:job_class) do
+    stub_active_job_class('MyJob') do
+      unique :until_expired
+    end
+  end
+
+  before do
+    described_class.test_mode!
+  end
+
+  after do
+    described_class.reset_manager!
+  end
+
+  it "doesn't lock in test mode" do
+    job_class.perform_later(1, 2)
+    expect(locks.count).to eq(0)
+  end
+
+  it 'locks after reset from test mode' do
+    described_class.reset_manager!
+    job_class.perform_later(1, 2)
+    expect(locks.count).to eq(1)
+  end
+end


### PR DESCRIPTION
It is useful to reset activejob-uniqueness to
normal state for testing purposes.

For example be able to test app and jobs behavior on
conflicts. Something that is not tested can always
break in unexpected ways. Especially something that
may happen rarely and would be hard to unerstand
in production.

fixes #41