### PR TITLE
Add Ruby 3.2.0 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,10 @@ jobs:
         ruby:
           - 2.5.9
           - 2.6.10
-          - 2.7.6
-          - 3.0.4
-          - 3.1.2
+          - 2.7.7
+          - 3.0.5
+          - 3.1.3
+          - 3.2.0
         gemfile:
           - gemfiles/activejob_4.2.x.gemfile
           - gemfiles/activejob_5.2.x.gemfile
@@ -48,27 +49,37 @@ jobs:
             gemfile: gemfiles/sidekiq_6.x.gemfile
           - ruby: 2.6.10
             gemfile: gemfiles/sidekiq_7.x.gemfile
-          - ruby: 2.7.6
+          - ruby: 2.7.7
             gemfile: gemfiles/activejob_4.2.x.gemfile
-          - ruby: 2.7.6
+          - ruby: 2.7.7
             gemfile: gemfiles/sidekiq_4.x.gemfile
-          - ruby: 3.0.4
+          - ruby: 3.0.5
             gemfile: gemfiles/activejob_4.2.x.gemfile
-          - ruby: 3.0.4
+          - ruby: 3.0.5
             gemfile: gemfiles/activejob_5.2.x.gemfile
-          - ruby: 3.0.4
+          - ruby: 3.0.5
             gemfile: gemfiles/sidekiq_4.x.gemfile
-          - ruby: 3.0.4
+          - ruby: 3.0.5
             gemfile: gemfiles/sidekiq_5.x.gemfile
-          - ruby: 3.1.2
+          - ruby: 3.1.3
             gemfile: gemfiles/activejob_4.2.x.gemfile
-          - ruby: 3.1.2
+          - ruby: 3.1.3
             gemfile: gemfiles/activejob_5.2.x.gemfile
-          - ruby: 3.1.2
+          - ruby: 3.1.3
             gemfile: gemfiles/activejob_6.0.x.gemfile
-          - ruby: 3.1.2
+          - ruby: 3.1.3
             gemfile: gemfiles/sidekiq_4.x.gemfile
-          - ruby: 3.1.2
+          - ruby: 3.1.3
+            gemfile: gemfiles/sidekiq_5.x.gemfile
+          - ruby: 3.2.0
+            gemfile: gemfiles/activejob_4.2.x.gemfile
+          - ruby: 3.2.0
+            gemfile: gemfiles/activejob_5.2.x.gemfile
+          - ruby: 3.2.0
+            gemfile: gemfiles/activejob_6.0.x.gemfile
+          - ruby: 3.2.0
+            gemfile: gemfiles/sidekiq_4.x.gemfile
+          - ruby: 3.2.0
             gemfile: gemfiles/sidekiq_5.x.gemfile
 
     steps:


### PR DESCRIPTION
Also updates patch versions on other Rubies.

Everything runs green on my fork.