### PR TITLE
Fix log subscriber

### DIFF
--- a/lib/active_job/uniqueness/log_subscriber.rb
+++ b/lib/active_job/uniqueness/log_subscriber.rb
@@ -3,98 +3,100 @@
 require 'active_support/log_subscriber'
 
 module ActiveJob
-  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
-    def lock(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+  module Uniqueness
+    class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
+      def lock(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      debug do
-        "Locked #{lock_info(job, resource)}" + args_info(job)
+        debug do
+          "Locked #{lock_info(job, resource)}" + args_info(job)
+        end
       end
-    end
 
-    def runtime_lock(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+      def runtime_lock(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      debug do
-        "Locked runtime #{lock_info(job, resource)}" + args_info(job)
+        debug do
+          "Locked runtime #{lock_info(job, resource)}" + args_info(job)
+        end
       end
-    end
 
-    def unlock(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+      def unlock(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      debug do
-        "Unlocked #{lock_info(job, resource)}"
+        debug do
+          "Unlocked #{lock_info(job, resource)}"
+        end
       end
-    end
 
-    def runtime_unlock(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+      def runtime_unlock(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      debug do
-        "Unlocked runtime #{lock_info(job, resource)}"
+        debug do
+          "Unlocked runtime #{lock_info(job, resource)}"
+        end
       end
-    end
 
-    def conflict(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+      def conflict(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      info do
-        "Not unique #{lock_info(job, resource)}" + args_info(job)
+        info do
+          "Not unique #{lock_info(job, resource)}" + args_info(job)
+        end
       end
-    end
 
-    def runtime_conflict(event)
-      job = event.payload[:job]
-      resource = event.payload[:resource]
+      def runtime_conflict(event)
+        job = event.payload[:job]
+        resource = event.payload[:resource]
 
-      info do
-        "Not unique runtime #{lock_info(job, resource)}" + args_info(job)
+        info do
+          "Not unique runtime #{lock_info(job, resource)}" + args_info(job)
+        end
       end
-    end
 
-    private
+      private
 
-    def lock_info(job, resource)
-      "#{job.class.name} (Job ID: #{job.job_id}) (Lock key: #{resource})"
-    end
-
-    def args_info(job)
-      if job.arguments.any? && log_arguments?(job)
-        " with arguments: #{job.arguments.map { |arg| format(arg).inspect }.join(', ')}"
-      else
-        ''
+      def lock_info(job, resource)
+        "#{job.class.name} (Job ID: #{job.job_id}) (Lock key: #{resource})"
       end
-    end
 
-    def log_arguments?(job)
-      return true unless job.class.respond_to?(:log_arguments?)
-
-      job.class.log_arguments?
-    end
-
-    def format(arg)
-      case arg
-      when Hash
-        arg.transform_values { |value| format(value) }
-      when Array
-        arg.map { |value| format(value) }
-      when GlobalID::Identification
-        arg.to_global_id rescue arg
-      else
-        arg
+      def args_info(job)
+        if job.arguments.any? && log_arguments?(job)
+          " with arguments: #{job.arguments.map { |arg| format(arg).inspect }.join(', ')}"
+        else
+          ''
+        end
       end
-    end
 
-    def logger
-      ActiveJob::Base.logger
+      def log_arguments?(job)
+        return true unless job.class.respond_to?(:log_arguments?)
+
+        job.class.log_arguments?
+      end
+
+      def format(arg)
+        case arg
+        when Hash
+          arg.transform_values { |value| format(value) }
+        when Array
+          arg.map { |value| format(value) }
+        when GlobalID::Identification
+          arg.to_global_id rescue arg
+        else
+          arg
+        end
+      end
+
+      def logger
+        ActiveJob::Base.logger
+      end
     end
   end
 end
 
-ActiveJob::LogSubscriber.attach_to :active_job_uniqueness
+ActiveJob::Uniqueness::LogSubscriber.attach_to :active_job_uniqueness


### PR DESCRIPTION
Using both [rails_semantic_logger](https://github.com/reidmorrison/rails_semantic_logger) and [activejob-uniqueness](https://github.com/veeqo/activejob-uniqueness) together in Rails 6.0.x results in duplicated logs as reported in https://github.com/veeqo/activejob-uniqueness/issues/73.

### The Issue

1. Rails 6.0.x has `ActiveJob::Logging::LogSubscriber.attach_to :active_job`.
2. `activejob-uniqueness` has `ActiveJob::LogSubscriber.attach_to :active_job_uniqueness`.
3. `rails_semantic_logger` _expects_ to see one of these but replaces **both of these**  with it's own logger [here](https://github.com/reidmorrison/rails_semantic_logger/blob/93fed9edd0ba21490044e5fc7474c7b83eb2676c/lib/rails_semantic_logger/engine.rb#L157-L171). And thus duplicating logging.

### The Solution

This PR ensures that we are creating and attaching a unique log subscriber `ActiveJob::Uniqueness::LogSubscriber` and not creating the `ActiveJob::LogSubscriber` class in older Rails versions.