### PR TITLE
Adjust to new redlock behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ class MyJob < ActiveJob::Base
 end
 ```
 
+### Control redis connection errors
+
+```ruby
+class MyJob < ActiveJob::Base
+  # Proc gets the job instance including its arguments, and as keyword arguments the resource(lock key) `resource` and the original error `error`
+  unique :until_executing, on_redis_connection_error: ->(job, resource: _, error: _) { job.logger.info "Oops: #{job.arguments}" }
+
+  def perform(args)
+    # work
+  end
+end
+```
+
 ### Control lock key arguments
 
 ```ruby

--- a/lib/active_job/uniqueness/active_job_patch.rb
+++ b/lib/active_job/uniqueness/active_job_patch.rb
@@ -41,7 +41,9 @@ module ActiveJob
 
         private
 
-        delegate :validate_on_conflict_action!, :validate_on_redis_connection_error!, to: :'ActiveJob::Uniqueness.config'
+        delegate :validate_on_conflict_action!,
+                 :validate_on_redis_connection_error!,
+                 to: :'ActiveJob::Uniqueness.config'
       end
 
       included do

--- a/lib/active_job/uniqueness/active_job_patch.rb
+++ b/lib/active_job/uniqueness/active_job_patch.rb
@@ -27,6 +27,7 @@ module ActiveJob
         def unique(strategy, options = {})
           validate_on_conflict_action!(options[:on_conflict])
           validate_on_conflict_action!(options[:on_runtime_conflict])
+          validate_on_redis_connection_error!(options[:on_redis_connection_error])
 
           self.lock_strategy_class = ActiveJob::Uniqueness::Strategies.lookup(strategy)
           self.lock_options = options
@@ -40,7 +41,7 @@ module ActiveJob
 
         private
 
-        delegate :validate_on_conflict_action!, to: :'ActiveJob::Uniqueness.config'
+        delegate :validate_on_conflict_action!, :validate_on_redis_connection_error!, to: :'ActiveJob::Uniqueness.config'
       end
 
       included do

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -14,6 +14,7 @@ module ActiveJob
       config_accessor(:lock_ttl) { 86_400 } # 1.day
       config_accessor(:lock_prefix) { 'activejob_uniqueness' }
       config_accessor(:on_conflict) { :raise }
+      config_accessor(:on_redis_connection_error) { :raise }
       config_accessor(:redlock_servers) { [ENV.fetch('REDIS_URL', 'redis://localhost:6379')] }
       config_accessor(:redlock_options) { { retry_count: 0 } }
       config_accessor(:lock_strategies) { {} }
@@ -33,6 +34,19 @@ module ActiveJob
         return if action.nil? || %i[log raise].include?(action) || action.respond_to?(:call)
 
         raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on conflict"
+      end
+
+
+      def on_redis_connection_error=(action)
+        validate_on_redis_connection_error!(action)
+
+        config.on_redis_connection_error = action
+      end
+
+      def validate_on_redis_connection_error!(action)
+        return if action.nil? || :raise == action || action.respond_to?(:call)
+
+        raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on_redis_connection_error"
       end
     end
   end

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -36,7 +36,6 @@ module ActiveJob
         raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on conflict"
       end
 
-
       def on_redis_connection_error=(action)
         validate_on_redis_connection_error!(action)
 
@@ -44,7 +43,7 @@ module ActiveJob
       end
 
       def validate_on_redis_connection_error!(action)
-        return if action.nil? || :raise == action || action.respond_to?(:call)
+        return if action.nil? || action == :raise || action.respond_to?(:call)
 
         raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on_redis_connection_error"
       end

--- a/lib/active_job/uniqueness/sidekiq_patch.rb
+++ b/lib/active_job/uniqueness/sidekiq_patch.rb
@@ -41,7 +41,7 @@ module ActiveJob
       module ScheduledSet
         def delete(score, job_id)
           entry = find_job(job_id)
-          ActiveJob::Uniqueness.unlock_sidekiq_job!(entry.item) if super(score, job_id)
+          ActiveJob::Uniqueness.unlock_sidekiq_job!(entry.item) if super
           entry
         end
       end
@@ -67,7 +67,7 @@ module ActiveJob
         end
 
         def delete_by_value(name, value)
-          ActiveJob::Uniqueness.unlock_sidekiq_job!(Sidekiq.load_json(value)) if super(name, value)
+          ActiveJob::Uniqueness.unlock_sidekiq_job!(Sidekiq.load_json(value)) if super
         end
       end
     end

--- a/lib/generators/active_job/uniqueness/templates/config/initializers/active_job_uniqueness.rb
+++ b/lib/generators/active_job/uniqueness/templates/config/initializers/active_job_uniqueness.rb
@@ -19,6 +19,13 @@ ActiveJob::Uniqueness.configure do |config|
   #
   # config.on_conflict = :raise
 
+  # Default action on redis connection error. Can be set per job.
+  # Allowed values are
+  #   :raise - raises ActiveJob::Uniqueness::JobNotUnique
+  #   proc - custom Proc. For example, ->(job, resource: _, error: _) { job.logger.info("Job already in queue: #{job.class.name} #{job.arguments.inspect} (#{job.job_id})") }
+  #
+  # config.on_conflict = :raise
+
   # Digest method for lock keys generating. Expected to have `hexdigest` class method.
   #
   # config.digest_method = OpenSSL::Digest::MD5

--- a/spec/support/shared_examples/enqueuing.rb
+++ b/spec/support/shared_examples/enqueuing.rb
@@ -65,6 +65,42 @@ shared_examples_for 'a strategy with unique jobs in the queue' do
       end
     end
 
+    context 'when locking fails due to RedisClient error' do
+      before do
+        job_class.unique strategy
+
+        allow_any_instance_of(ActiveJob::Uniqueness::LockManager).to receive(:lock).and_raise(RedisClient::ConnectionError)
+      end
+
+      shared_examples 'of no jobs enqueued' do
+        it 'does not enqueue the job' do
+          expect { suppress(RedisClient::ConnectionError) { subject } }.not_to change(enqueued_jobs, :count)
+        end
+
+        it 'does not remove the existing lock' do
+          expect { suppress(RedisClient::ConnectionError) { subject } }.not_to change(locks, :count)
+        end
+      end
+
+      context 'when no options given' do
+        include_examples 'of no jobs enqueued'
+
+        it 'raises a RedisClient::ConnectionError error' do
+          expect { subject }.to raise_error RedisClient::ConnectionError
+        end
+      end
+
+      context 'when on_redis_connection_error: Proc given' do
+        before { job_class.unique strategy, on_redis_connection_error: ->(job, **_kwargs) { job.logger.info('Oops') } }
+
+        include_examples 'of no jobs enqueued'
+
+        it 'calls the Proc' do
+          expect { subject }.to log(/Oops/)
+        end
+      end
+    end
+
     context 'when the lock exists' do
       before do
         job_class.unique strategy

--- a/spec/support/shared_examples/enqueuing.rb
+++ b/spec/support/shared_examples/enqueuing.rb
@@ -90,6 +90,16 @@ shared_examples_for 'a strategy with unique jobs in the queue' do
         end
       end
 
+      context 'when on_redis_connection_error: :raise given' do
+        before { job_class.unique strategy, on_redis_connection_error: :raise }
+
+        include_examples 'of no jobs enqueued'
+
+        it 'raises a RedisClient::ConnectionError error' do
+          expect { subject }.to raise_error RedisClient::ConnectionError
+        end
+      end
+
       context 'when on_redis_connection_error: Proc given' do
         before { job_class.unique strategy, on_redis_connection_error: ->(job, **_kwargs) { job.logger.info('Oops') } }
 


### PR DESCRIPTION
There have been some changes to the behaviour of `redis-client` and `redlock-rb` which lead to a different behaviour in this gem.

Before https://github.com/leandromoreira/redlock-rb/pull/110 was merged, redlock would return `false` if there was an error with the connection, now it raises the error.
Before this behaviour could have been handled by configuring `on_conflict`. Now the behaviour should be more fine grained.

This adds a `on_error` option, which can be either `nil` (leading to a reraise) or a `proc` leading to the evaluation of said proc.

This allows users to handle connections errors to reduce the amount of jobs that get lost because of said connection errors. 