### PR TITLE
Implement reject conflict strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/activejob-uniqueness/compare/v0.4.0...HEAD)
 
+### Added
+
+- [#88](https://github.com/veeqo/activejob-uniqueness/pull/88) Implement reject conflict strategy by[@dmitrytsepelev](https://github.com/dmitrytsepelev)
 
 ## [0.4.0](https://github.com/veeqo/activejob-uniqueness/compare/v0.3.2...v0.4.0) - 2024-12-07
 

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -31,7 +31,7 @@ module ActiveJob
       end
 
       def validate_on_conflict_action!(action)
-        return if action.nil? || %i[log raise].include?(action) || action.respond_to?(:call)
+        return if action.nil? || %i[log raise reject].include?(action) || action.respond_to?(:call)
 
         raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on conflict"
       end

--- a/lib/active_job/uniqueness/strategies/base.rb
+++ b/lib/active_job/uniqueness/strategies/base.rb
@@ -88,6 +88,8 @@ module ActiveJob
           case on_conflict
           when :log then instrument(event, resource: resource)
           when :raise then raise_not_unique_job_error(resource: resource, event: event)
+          when :reject
+            # do nothing
           else
             on_conflict.call(job)
           end

--- a/spec/active_job/uniqueness/active_job_patch/unique_spec.rb
+++ b/spec/active_job/uniqueness/active_job_patch/unique_spec.rb
@@ -61,6 +61,17 @@ describe ActiveJob::Uniqueness::ActiveJobPatch, '.unique' do
     end
   end
 
+  context 'when on_conflict: :reject action is given' do
+    subject(:make_job_unique) { job_class.unique :until_executed, on_conflict: :reject }
+
+    it 'sets proper values for lock variables', :aggregate_failures do
+      make_job_unique
+
+      expect(job_class.lock_strategy_class).to eq(ActiveJob::Uniqueness::Strategies::UntilExecuted)
+      expect(job_class.lock_options).to eq({ on_conflict: :reject })
+    end
+  end
+
   context 'when on_conflict: Proc action is given' do
     subject(:make_job_unique) { job_class.unique :until_executed, on_conflict: custom_proc }
 

--- a/spec/active_job/uniqueness/strategies/until_and_while_executing_spec.rb
+++ b/spec/active_job/uniqueness/strategies/until_and_while_executing_spec.rb
@@ -137,6 +137,24 @@ describe ':until_and_while_executing strategy', type: :integration do
         end
       end
 
+      context 'when on_conflict: :reject given' do
+        let(:job_class) do
+          stub_active_job_class do
+            unique :until_and_while_executing, on_conflict: :reject
+          end
+        end
+
+        include_examples 'of a not unique job processing'
+
+        it 'does not raise ActiveJob::Uniqueness::JobNotUnique' do
+          expect { process }.not_to raise_error
+        end
+
+        it 'does not log the skipped job' do
+          expect { process }.not_to log(/Not unique/)
+        end
+      end
+
       context 'when on_conflict: Proc given' do
         let(:job_class) do
           stub_active_job_class do

--- a/spec/active_job/uniqueness/strategies/while_executing_spec.rb
+++ b/spec/active_job/uniqueness/strategies/while_executing_spec.rb
@@ -117,6 +117,24 @@ describe ':while_executing strategy', type: :integration do
         end
       end
 
+      context 'when on_conflict: :reject given' do
+        let(:job_class) do
+          stub_active_job_class do
+            unique :while_executing, on_conflict: :reject
+          end
+        end
+
+        include_examples 'of a not unique job processing'
+
+        it 'does not raise ActiveJob::Uniqueness::JobNotUnique' do
+          expect { process }.not_to raise_error
+        end
+
+        it 'does not log the skipped job' do
+          expect { process }.not_to log(/Not unique/)
+        end
+      end
+
       context 'when on_conflict: Proc given' do
         let(:job_class) do
           stub_active_job_class do

--- a/spec/support/shared_examples/enqueuing.rb
+++ b/spec/support/shared_examples/enqueuing.rb
@@ -154,6 +154,18 @@ shared_examples_for 'a strategy with unique jobs in the queue' do
         end
       end
 
+      context 'when on_conflict: :reject given' do
+        before { job_class.unique strategy, on_conflict: :reject }
+
+        it 'does not raise ActiveJob::Uniqueness::JobNotUnique' do
+          expect { subject }.not_to raise_error
+        end
+
+        it 'does not log the skipped job' do
+          expect { subject }.not_to log(/Not unique/)
+        end
+      end
+
       context 'when on_conflict: Proc given' do
         before { job_class.unique strategy, on_conflict: ->(job) { job.logger.info('Oops') } }
 


### PR DESCRIPTION
That's a pretty dumb strategy to implement, but I feel like writing `unique :until_executed, on_conflict: :reject` is a bit more readable than `unique :until_executed, on_conflict: ->(_) {}` in cases, when I know that there will be a ton of conflicts, I expect that and do not want to be notified