### PR TITLE
feat: support sidekiq 8

### DIFF
--- a/lib/active_job/uniqueness/sidekiq_patch.rb
+++ b/lib/active_job/uniqueness/sidekiq_patch.rb
@@ -6,7 +6,9 @@ require 'sidekiq/api'
 module ActiveJob
   module Uniqueness
     def self.unlock_sidekiq_job!(job_data)
-      return unless job_data['class'] == 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper' # non ActiveJob jobs
+      unless %w[ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper Sidekiq::ActiveJob::Wrapper].include?(job_data['class'])
+        return
+      end
 
       job = ActiveJob::Base.deserialize(job_data.fetch('args').first)
 

--- a/lib/active_job/uniqueness/sidekiq_patch.rb
+++ b/lib/active_job/uniqueness/sidekiq_patch.rb
@@ -5,10 +5,13 @@ require 'sidekiq/api'
 
 module ActiveJob
   module Uniqueness
+    SIDEKIQ_JOB_WRAPPERS = %w[
+      ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper
+      Sidekiq::ActiveJob::Wrapper
+    ].freeze
+
     def self.unlock_sidekiq_job!(job_data)
-      unless %w[ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper Sidekiq::ActiveJob::Wrapper].include?(job_data['class'])
-        return
-      end
+      return unless SIDEKIQ_JOB_WRAPPERS.include?(job_data['class'])
 
       job = ActiveJob::Base.deserialize(job_data.fetch('args').first)
 


### PR DESCRIPTION
This addresses #87

Wrapper class names for Active Job support have changed in Sidekiq 8. https://github.com/sidekiq/sidekiq/blob/main/Changes.md#800
> WARNING The underlying class name for Active Jobs has changed from ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper to Sidekiq::ActiveJob::Wrapper. The old name will still work in 8.x.

Adding Sidekiq::ActiveJob::Wrapper to the class check in the sidekiq patch.