### PR TITLE
Merge redlock_options with defaults

### DIFF
--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -51,6 +51,9 @@ module ActiveJob
       end
 
       def redlock_options=(options)
+        options ||= {}
+        raise ArgumentError, "redlock_options must be a Hash-like object, got #{options.class}" unless options.respond_to?(:to_hash)
+
         config.redlock_options = REDLOCK_DEFAULTS.merge(options)
       end
     end

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -11,12 +11,14 @@ module ActiveJob
     class Configuration
       include ActiveSupport::Configurable
 
+      REDLOCK_DEFAULTS = { retry_count: 0 }.freeze
+
       config_accessor(:lock_ttl) { 86_400 } # 1.day
       config_accessor(:lock_prefix) { 'activejob_uniqueness' }
       config_accessor(:on_conflict) { :raise }
       config_accessor(:on_redis_connection_error) { :raise }
       config_accessor(:redlock_servers) { [ENV.fetch('REDIS_URL', 'redis://localhost:6379')] }
-      config_accessor(:redlock_options) { { retry_count: 0 } }
+      config_accessor(:redlock_options) { REDLOCK_DEFAULTS }
       config_accessor(:lock_strategies) { {} }
 
       config_accessor(:digest_method) do
@@ -46,6 +48,10 @@ module ActiveJob
         return if action.nil? || action == :raise || action.respond_to?(:call)
 
         raise ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected '#{action}' action on_redis_connection_error"
+      end
+
+      def redlock_options=(options)
+        config.redlock_options = REDLOCK_DEFAULTS.merge(options)
       end
     end
   end

--- a/lib/active_job/uniqueness/configuration.rb
+++ b/lib/active_job/uniqueness/configuration.rb
@@ -18,7 +18,7 @@ module ActiveJob
       config_accessor(:on_conflict) { :raise }
       config_accessor(:on_redis_connection_error) { :raise }
       config_accessor(:redlock_servers) { [ENV.fetch('REDIS_URL', 'redis://localhost:6379')] }
-      config_accessor(:redlock_options) { REDLOCK_DEFAULTS }
+      config_accessor(:redlock_options) { REDLOCK_DEFAULTS.dup }
       config_accessor(:lock_strategies) { {} }
 
       config_accessor(:digest_method) do

--- a/spec/active_job/uniqueness/configure_spec.rb
+++ b/spec/active_job/uniqueness/configure_spec.rb
@@ -103,4 +103,28 @@ describe ActiveJob::Uniqueness, '.configure' do
         .to({ retry_count: 1 })
     end
   end
+
+  context 'when redlock_options has been set to nil' do
+    subject(:configure) do
+      described_class.configure do |c|
+        c.redlock_options = nil
+      end
+    end
+
+    it 'uses defaults' do
+      expect { configure }.to not_change(config, :redlock_options).from({ retry_count: 0 })
+    end
+  end
+
+  context 'when redlock_options has been set to non-hash-like value' do
+    subject(:configure) do
+      described_class.configure do |c|
+        c.redlock_options = 'invalid'
+      end
+    end
+
+    it 'raises ArgumentError' do
+      expect { configure }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/active_job/uniqueness/configure_spec.rb
+++ b/spec/active_job/uniqueness/configure_spec.rb
@@ -75,4 +75,32 @@ describe ActiveJob::Uniqueness, '.configure' do
       expect { configure }.to raise_error(ActiveJob::Uniqueness::InvalidOnConflictAction, "Unexpected 'panic' action on conflict")
     end
   end
+
+  context 'when redlock_options has been set' do
+    subject(:configure) do
+      described_class.configure do |c|
+        c.redlock_options = { redis_timeout: 0.05 }
+      end
+    end
+
+    it 'merges with defaults' do
+      expect { configure }.to change(config, :redlock_options)
+        .from({ retry_count: 0 })
+        .to({ retry_count: 0, redis_timeout: 0.05 })
+    end
+  end
+
+  context 'when redlock_options has been set with retry_count' do
+    subject(:configure) do
+      described_class.configure do |c|
+        c.redlock_options = { retry_count: 1 }
+      end
+    end
+
+    it 'overwrites the defaults' do
+      expect { configure }.to change(config, :redlock_options)
+        .from({ retry_count: 0 })
+        .to({ retry_count: 1 })
+    end
+  end
 end


### PR DESCRIPTION
The setter for `redlock_options` overwrites the default `retry_count` of 0. That triggers a fallback to redlock's [default retry behavior](https://github.com/leandromoreira/redlock-rb/blob/eb32b54b639adbacb6ef0ebfb8cf3a6ddb249704/lib/redlock/client.rb#L22-L24), which is 3 attempts with a 200ms–250ms sleep in between each. That means a 600ms–750ms performance penalty for accidentally omitting this option. We can easily avoid this mistake by merging with the defaults.